### PR TITLE
Use rot.js from WebJars

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ name := "Keter"
 
 scalaVersion := "2.11.5"
 
-resolvers += Resolver.mavenLocal
-
 libraryDependencies ++= Seq(
   "org.scala-js" %%% "scalajs-dom" % "0.8.0",
   "org.webjars" % "rot.js" % "0.5.0"

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,14 @@ name := "Keter"
 
 scalaVersion := "2.11.5"
 
+resolvers += Resolver.mavenLocal
+
 libraryDependencies ++= Seq(
   "org.scala-js" %%% "scalajs-dom" % "0.8.0",
-  "org.webjars" % "jquery" % "1.10.2"
+  "org.webjars" % "rot.js" % "0.5.0"
 )
 
-jsDependencies += "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+jsDependencies += "org.webjars" % "rot.js" % "0.5.0" / "rot.min.js"
 
 skip in packageJSDependencies := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,17 @@
-scalaJSSettings
+enablePlugins(ScalaJSPlugin)
 
 name := "Keter"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.5"
 
-libraryDependencies += "org.scala-lang.modules.scalajs" %%% "scalajs-dom" % "0.6"
+libraryDependencies ++= Seq(
+  "org.scala-js" %%% "scalajs-dom" % "0.8.0",
+  "org.webjars" % "jquery" % "1.10.2"
+)
+
+jsDependencies += "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+
+skip in packageJSDependencies := false
 
 lazy val sitePath = settingKey[String]("Directory for the site")
 
@@ -14,15 +21,18 @@ sitePath := "site"
 
 site := {
   import java.nio.file.{Files, StandardCopyOption}
-  (ScalaJSKeys.fastOptJS in Compile).value
+  (fastOptJS in Compile).value
   val targetDirectory = target.value / sitePath.value
   val sourceJS = target.value / "scala-2.11" / "keter-fastopt.js"
   val sourceMap = target.value / "scala-2.11" / "keter-fastopt.js.map"
+  val sourceJSDeps = target.value / "scala-2.11" / "keter-jsdeps.js"
   val targetJS = targetDirectory / "keter.js"
   val targetMap = targetDirectory / sourceMap.name
+  val targetJSDeps = targetDirectory / sourceJSDeps.name
   targetJS.mkdirs()
   Files.copy(sourceJS.toPath, targetJS.toPath, StandardCopyOption.REPLACE_EXISTING)
   Files.copy(sourceMap.toPath, targetMap.toPath, StandardCopyOption.REPLACE_EXISTING)
+  Files.copy(sourceJSDeps.toPath, targetJSDeps.toPath, StandardCopyOption.REPLACE_EXISTING)
   (resourceDirectory in Compile).value.listFiles() foreach { file =>
     val targetFile = targetDirectory / file.name
     Files.copy(file.toPath, targetFile.toPath, StandardCopyOption.REPLACE_EXISTING)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.5.4")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0")

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -2,9 +2,14 @@
 <html>
 	<head>
 		<title>Keter</title>
-		<script src="https://ondras.github.io/rot.js/rot.js"></script>
+		<script src="keter-jsdeps.js"></script>
 		<script src="keter.js"></script>
 	</head>
 	<body onload="ru.org.codingteam.keter.Application().main()">
+    <script>
+        jQuery(function () {
+            alert('loaded');
+        });
+    </script>
 	</body>
 </html>

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -6,10 +6,5 @@
 		<script src="keter.js"></script>
 	</head>
 	<body onload="ru.org.codingteam.keter.Application().main()">
-    <script>
-        jQuery(function () {
-            alert('loaded');
-        });
-    </script>
 	</body>
 </html>


### PR DESCRIPTION
I've successfully managed to publish rot.js to WebJars and we can use the published artifact. Also I've updated sbt, scala and Scala.js versions (because we need all that stuff to use WebJars).

Closes #1.