### PR TITLE
Equipment category view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: scala
 jdk: oraclejdk8
 scala:

--- a/src/main/scala/ru/org/codingteam/keter/game/objects/equipment/EquipmentCategory.scala
+++ b/src/main/scala/ru/org/codingteam/keter/game/objects/equipment/EquipmentCategory.scala
@@ -1,0 +1,6 @@
+package ru.org.codingteam.keter.game.objects.equipment
+
+object EquipmentCategory extends Enumeration {
+  type EquipmentCategory = Value
+  val All, Weapon = Value
+}

--- a/src/main/scala/ru/org/codingteam/keter/scenes/game/GameMapView.scala
+++ b/src/main/scala/ru/org/codingteam/keter/scenes/game/GameMapView.scala
@@ -5,16 +5,14 @@ import ru.org.codingteam.keter.game.objects._
 import ru.org.codingteam.keter.map.TraverseUtils.{BoardCell, BoardCoords}
 import ru.org.codingteam.keter.map.{Surface, TraverseUtils}
 import ru.org.codingteam.keter.ui.IView
+import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.util.Logging
 import ru.org.codingteam.rotjs.interface.Display
 import ru.org.codingteam.rotjs.wrappers._
 
-class GameMapView(parent: GameScene, width: Int, height: Int, viewModel: GameMapViewModel) extends IView with Logging {
+class GameMapView(shape: Rectangle, parent: GameScene, viewModel: GameMapViewModel) extends IView with Logging {
 
   import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-
-  var x = 0
-  var y = 0
 
   val keyMap = {
     import ru.org.codingteam.rotjs.interface.ROT._
@@ -48,7 +46,7 @@ class GameMapView(parent: GameScene, width: Int, height: Int, viewModel: GameMap
   override def render(display: Display): Unit = {
     log.debug("Render called")
     for (universeState <- viewModel.universeState; player <- universeState.player) {
-      val fieldContainer = display.viewport(x, y, width, height)
+      val fieldContainer = display.viewport(shape.x, shape.y, shape.width, shape.height)
       //      log.debug("Drawing field")
       val (offsetX, offsetY) = (fieldContainer.width / 2 - 1, fieldContainer.height / 2 - 1)
       val (fieldWidth, fieldHeight) = (offsetX * 2 + 1, offsetY * 2 + 1)

--- a/src/main/scala/ru/org/codingteam/keter/scenes/game/GameScene.scala
+++ b/src/main/scala/ru/org/codingteam/keter/scenes/game/GameScene.scala
@@ -2,6 +2,7 @@ package ru.org.codingteam.keter.scenes.game
 
 import ru.org.codingteam.keter.game.Engine
 import ru.org.codingteam.keter.ui.ViewScene
+import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.util.Logging
 import ru.org.codingteam.rotjs.interface.Display
 import ru.org.codingteam.rotjs.wrappers._
@@ -10,8 +11,8 @@ class GameScene(display: Display, engine: Engine) extends ViewScene(display) wit
 
   val viewModel = new GameViewModel(engine)
   override def components = Vector(
-    gameMapView(1, 1, display.width - 2, display.height - 5, viewModel.map),
-    textView(0, display.height - 3, display.width, 3, viewModel.statInfo))
+    gameMapView(Rectangle(1, 1, display.width - 2, display.height - 5), viewModel.map),
+    textView(Rectangle(0, display.height - 3, display.width, 3), viewModel.statInfo))
 
   // GameScene shouldn't be rendered on key down and will be rendered on asynchronous game state change
   override protected def renderOnKeyDown: Boolean = false
@@ -22,11 +23,5 @@ class GameScene(display: Display, engine: Engine) extends ViewScene(display) wit
     }
   })
 
-  def gameMapView(x: Int, y: Int, width: Int, height: Int, viewModel: GameMapViewModel) = {
-    val view = new GameMapView(this, width, height, viewModel)
-    view.x = x
-    view.y = y
-    view
-  }
-
+  def gameMapView(shape: Rectangle, viewModel: GameMapViewModel) = new GameMapView(shape, this, viewModel)
 }

--- a/src/main/scala/ru/org/codingteam/keter/scenes/inventory/InventoryScene.scala
+++ b/src/main/scala/ru/org/codingteam/keter/scenes/inventory/InventoryScene.scala
@@ -5,6 +5,7 @@ import ru.org.codingteam.keter.Application
 import ru.org.codingteam.keter.game.objects.Inventory
 import ru.org.codingteam.keter.scenes.Scene
 import ru.org.codingteam.keter.ui.ViewScene
+import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.util.Logging
 import ru.org.codingteam.rotjs.interface.ROT
 
@@ -17,9 +18,9 @@ class InventoryScene(parentScene: Scene, inventory: Inventory)
   val result: Future[Option[Inventory]] = viewModel.result
 
   override val components = Vector(
-    listView(0, 0, 40, 40, backpackItems),
-    listView(40, 0, 40, 40, currentFolderItems),
-    textView(0, 40, 80, 40, currentItemInfo))
+    listView(Rectangle(0, 0, 40, 40), backpackCategories),
+    listView(Rectangle(40, 0, 40, 40), currentFolderItems),
+    textView(Rectangle(0, 40, 80, 40), currentItemInfo))
 
   override def onKeyDown(event: KeyboardEvent): Unit = {
     super.onKeyDown(event)
@@ -31,10 +32,9 @@ class InventoryScene(parentScene: Scene, inventory: Inventory)
     }
   }
 
-  private def backpackItems = viewModel.backpackItems
+  private def backpackCategories = viewModel.backpackCategories
   private def currentFolderItems = viewModel.currentFolderItems
   private def currentItemInfo = viewModel.currentItemInfo
-
 }
 
 object InventoryScene {
@@ -44,5 +44,4 @@ object InventoryScene {
     Application.setScene(inventoryScene)
     inventoryScene.viewModel.result
   }
-
 }

--- a/src/main/scala/ru/org/codingteam/keter/scenes/inventory/InventoryViewModel.scala
+++ b/src/main/scala/ru/org/codingteam/keter/scenes/inventory/InventoryViewModel.scala
@@ -1,8 +1,10 @@
 package ru.org.codingteam.keter.scenes.inventory
 
 import ru.org.codingteam.keter.game.objects.Inventory
+import ru.org.codingteam.keter.game.objects.equipment.{EquipmentCategory, EquipmentItem}
 import ru.org.codingteam.keter.ui.viewmodels.{ItemsViewModel, StaticTextViewModel}
 
+import scala.collection.immutable.ListMap
 import scala.concurrent.Promise
 
 class InventoryViewModel(var inventory: Inventory) {
@@ -18,8 +20,9 @@ class InventoryViewModel(var inventory: Inventory) {
     promise.success(None)
   }
 
-  def backpackItems = new ItemsViewModel() // TODO: Implement source
-  def currentFolderItems = new ItemsViewModel() // TODO: Implement change logic
+  def backpackCategories = new ItemsViewModel(
+    ListMap(EquipmentCategory.All -> "ALL", EquipmentCategory.Weapon -> "Weapons")
+  )
+  def currentFolderItems = new ItemsViewModel[EquipmentItem](ListMap()) // TODO: Implement change logic
   def currentItemInfo = new StaticTextViewModel("") // TODO: Implement logic
-
 }

--- a/src/main/scala/ru/org/codingteam/keter/ui/ViewScene.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/ViewScene.scala
@@ -3,8 +3,9 @@ package ru.org.codingteam.keter.ui
 import org.scalajs.dom.KeyboardEvent
 import ru.org.codingteam.keter.Application
 import ru.org.codingteam.keter.scenes.Scene
+import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.ui.viewmodels.{StaticTextViewModel, MenuViewModel, TextViewModel, ItemsViewModel}
-import ru.org.codingteam.keter.ui.views.{TextView, MenuView}
+import ru.org.codingteam.keter.ui.views.{ListView, TextView, MenuView}
 import ru.org.codingteam.keter.util.Logging
 import ru.org.codingteam.rotjs.interface.Display
 import ru.org.codingteam.rotjs.wrappers._
@@ -14,7 +15,7 @@ abstract class ViewScene(display: Display) extends Scene(display) with Logging {
   def components: Vector[IView]
   private var activeComponent: Option[IView] = None
 
-  protected def renderOnKeyDown = Application.currentScene == Some(this)
+  protected def renderOnKeyDown = Application.currentScene.contains(this)
 
   override def render(): Unit = {
     log.debug("render")
@@ -36,15 +37,9 @@ abstract class ViewScene(display: Display) extends Scene(display) with Logging {
     }
   }
 
-  protected def listView(x: Int, y: Int, width: Int, height: Int, model: ItemsViewModel) = ???
-  protected def textView(x: Int, y: Int, width: Int, height: Int, model: TextViewModel): TextView = {
-    val view = new TextView(width, height, model)
-    view.x = x
-    view.y = y
-    view
-  }
-  protected def textView(model: TextViewModel): TextView = textView(0, 0, display.width, display.height, model)
+  protected def listView[T](shape: Rectangle, model: ItemsViewModel[T]) = new ListView(shape, model)
+  protected def textView(shape: Rectangle, model: TextViewModel) = new TextView(shape, model)
+  protected def textView(model: TextViewModel): TextView = textView(Rectangle(0, 0, display.width, display.height), model)
   protected def textView(text: String): TextView = textView(new StaticTextViewModel(text))
   protected def menu(model: MenuViewModel) = new MenuView(model)
-
 }

--- a/src/main/scala/ru/org/codingteam/keter/ui/shape/Rectangle.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/shape/Rectangle.scala
@@ -1,0 +1,3 @@
+package ru.org.codingteam.keter.ui.shape
+
+case class Rectangle(x: Int, y: Int, width: Int, height: Int)

--- a/src/main/scala/ru/org/codingteam/keter/ui/viewmodels/ItemsViewModel.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/viewmodels/ItemsViewModel.scala
@@ -2,6 +2,39 @@ package ru.org.codingteam.keter.ui.viewmodels
 
 import scala.collection.immutable.ListMap
 
-class ItemsViewModel[T](values: ListMap[T, String]) {
+class ItemsViewModel[T](initialItems: ListMap[T, String]) {
 
+  private var _items: ListMap[T, String] = initialItems
+  private var _selectedIndex: Option[Int] = initialIndex()
+
+  def items = _items
+  def items_=(newItems: ListMap[T, String]): Unit = {
+    _items = newItems
+    _selectedIndex = initialIndex()
+  }
+
+  def selectedIndex = _selectedIndex
+  def selectedIndex_=(newIndex: Option[Int]): Unit = {
+    newIndex match {
+      case None =>
+        _selectedIndex = newIndex
+      case Some(index) if _items.isEmpty => // Nothing
+      case Some(index) if index < 0 =>
+        _selectedIndex = Some(_items.size - 1)
+      case Some(index) if index >= _items.size =>
+        _selectedIndex = Some(0)
+      case Some(index) =>
+        _selectedIndex = newIndex
+    }
+  }
+
+  def up(): Unit = {
+    _selectedIndex foreach { value => selectedIndex = Some(value - 1) }
+  }
+
+  def down(): Unit = {
+    _selectedIndex foreach { value => selectedIndex = Some(value + 1) }
+  }
+
+  private def initialIndex(): Option[Int] = _items.headOption.map(_ => 0)
 }

--- a/src/main/scala/ru/org/codingteam/keter/ui/viewmodels/ItemsViewModel.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/viewmodels/ItemsViewModel.scala
@@ -1,5 +1,7 @@
 package ru.org.codingteam.keter.ui.viewmodels
 
-class ItemsViewModel() {
+import scala.collection.immutable.ListMap
+
+class ItemsViewModel[T](values: ListMap[T, String]) {
 
 }

--- a/src/main/scala/ru/org/codingteam/keter/ui/views/ListView.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/views/ListView.scala
@@ -1,0 +1,17 @@
+package ru.org.codingteam.keter.ui.views
+
+import org.scalajs.dom.KeyboardEvent
+import ru.org.codingteam.keter.ui.IView
+import ru.org.codingteam.keter.ui.shape.Rectangle
+import ru.org.codingteam.keter.ui.viewmodels.ItemsViewModel
+import ru.org.codingteam.rotjs.interface.Display
+
+/**
+ * A list of typed items.
+ */
+class ListView[T](shape: Rectangle, model: ItemsViewModel[T]) extends IView {
+
+  override def render(display: Display): Unit = ???
+
+  override def onKeyDown(event: KeyboardEvent): Unit = ???
+}

--- a/src/main/scala/ru/org/codingteam/keter/ui/views/ListView.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/views/ListView.scala
@@ -1,17 +1,33 @@
 package ru.org.codingteam.keter.ui.views
 
-import org.scalajs.dom.KeyboardEvent
-import ru.org.codingteam.keter.ui.IView
+import ru.org.codingteam.keter.ui.SimpleKeyMapView
 import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.ui.viewmodels.ItemsViewModel
-import ru.org.codingteam.rotjs.interface.Display
+import ru.org.codingteam.rotjs.interface.{ROT, Display}
 
 /**
  * A list of typed items.
  */
-class ListView[T](shape: Rectangle, model: ItemsViewModel[T]) extends IView {
+class ListView[T](shape: Rectangle, model: ItemsViewModel[T]) extends SimpleKeyMapView {
 
-  override def render(display: Display): Unit = ???
+  override def render(display: Display): Unit = {
+    val margin = 1
+    model.items.zipWithIndex foreach { case ((value, name), index) =>
+      val y = shape.y + index
+      if (index > shape.height) {
+        return
+      }
 
-  override def onKeyDown(event: KeyboardEvent): Unit = ???
+      if (model.selectedIndex.contains(index)) {
+        display.draw(shape.x, y, ">")
+      }
+
+      display.drawText(shape.x + margin, y, name, shape.width - 2 * margin)
+    }
+  }
+
+  override val keyMap = Map(
+    ROT.VK_OPEN_BRACKET -> model.up _,
+    ROT.VK_CLOSE_BRACKET -> model.down _
+  )
 }

--- a/src/main/scala/ru/org/codingteam/keter/ui/views/TextView.scala
+++ b/src/main/scala/ru/org/codingteam/keter/ui/views/TextView.scala
@@ -2,19 +2,16 @@ package ru.org.codingteam.keter.ui.views
 
 import org.scalajs.dom.KeyboardEvent
 import ru.org.codingteam.keter.ui.IView
+import ru.org.codingteam.keter.ui.shape.Rectangle
 import ru.org.codingteam.keter.ui.viewmodels.TextViewModel
 import ru.org.codingteam.rotjs.interface.Display
 import ru.org.codingteam.rotjs.wrappers._
 
-class TextView(var width: Int, var height: Int, model: TextViewModel) extends IView {
-
-  var x: Int = 0
-  var y: Int = 0
+class TextView(shape: Rectangle, model: TextViewModel) extends IView {
 
   override def render(display: Display): Unit = {
-    display.drawTextCentered(x, y, width, height, model.text, None)
+    display.drawTextCentered(shape.x, shape.y, shape.width, shape.height, model.text, None)
   }
 
   override def onKeyDown(event: KeyboardEvent): Unit = ()
-
 }

--- a/src/main/scala/ru/org/codingteam/rotjs/interface/ROT.scala
+++ b/src/main/scala/ru/org/codingteam/rotjs/interface/ROT.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 object ROT extends js.Object {
 
   def VK_A: Int = ???
+  def VK_CLOSE_BRACKET: Int = ???
   def VK_DOWN: Int = ???
   def VK_ENTER: Int = ???
   def VK_ESCAPE: Int = ???
@@ -20,8 +21,8 @@ object ROT extends js.Object {
   def VK_NUMPAD7: Int = ???
   def VK_NUMPAD8: Int = ???
   def VK_NUMPAD9: Int = ???
+  def VK_OPEN_BRACKET: Int = ???
   def VK_RETURN: Int = ???
   def VK_RIGHT: Int = ???
   def VK_UP: Int = ???
-
 }


### PR DESCRIPTION
I've started work on the inventory screen. Today we'll have only equipment category list that looks like this:

![image](https://cloud.githubusercontent.com/assets/92793/8638302/f6df1bb2-28d8-11e5-9cc5-ed8b037e0615.png)

Yeah, that looks like a tiny change, but really it took some work to implement all this `ItemsViewModel` and `ListView` machinery. That will be reused many times for implementing other item lists in inventory / equipment screens.