### PR TITLE
Build system level up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,9 @@ libraryDependencies ++= Seq(
 )
 
 npmDependencies in Compile += "rot-js" -> "0.6.2"
+npmDependencies in Compile += "webpack" -> "1.14.0"
+
+scalaJSUseMainModuleInitializer := true
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 
@@ -30,8 +33,8 @@ site := {
   import java.nio.file.{Files, StandardCopyOption}
   (webpack in fullOptJS in Compile).value
   val targetDirectory = target.value / sitePath.value
-  val sourceJS = target.value / "scala-2.11" / "keter-opt-bundle.js"
-  val sourceMap = target.value / "scala-2.11" / "keter-opt-bundle.js.map"
+  val sourceJS = target.value / "scala-2.11" / "scalajs-bundler" / "main" / "keter-opt-bundle.js"
+  val sourceMap = target.value / "scala-2.11" / "scalajs-bundler" / "main" / "keter-opt-bundle.js.map"
   val targetJS = targetDirectory / "keter.js"
   val targetMap = targetDirectory / sourceMap.name
   targetJS.mkdirs()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.2.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")


### PR DESCRIPTION
1. Upgrade sbt to deal with newer JDK versions, fix issues [like that](https://github.com/sbt/sbt/issues/4259).
2. Add a webpack dependency to fix issue reported by @bodqhrohro (apparently our CI now experiences it, too).
3. Update Scala.js bundler (without update it wasn't able to produce proper bundle); fix paths for the new bundler version.
4. Due to bundler update I had to update Scala.js as well. After that, I momentarily encountered some new shitty-gritty issues with `scalaJSUseMainModuleInitializer`, but was able to overcome them.